### PR TITLE
Fix cylinder and circle rotation.

### DIFF
--- a/qt-cao-editor/app/main.cpp
+++ b/qt-cao-editor/app/main.cpp
@@ -39,16 +39,9 @@
 ****************************************************************************/
 
 #include <QApplication>
-#include <QQuickWidget>
-#include <QMdiArea>
-#include <QMenuBar>
 #include <QCommandLineParser>
-#include <QCommandLineOption>
-#include <QLCDNumber>
-#include <QGuiApplication>
 
 #include "mainwindow.h"
-
 #include "scenemodifier.h"
 
 
@@ -81,7 +74,7 @@ int main(int argc, char **argv)
 
 //    cameraEntity->setProjectionType(Qt3DRender::QCameraLens::PerspectiveProjection);
     mainWin.cameraEntity->lens()->setPerspectiveProjection(45.0f, 16.0f/9.0f, 0.1f, 1000.0f);
-    mainWin.cameraEntity->setPosition(QVector3D(0, 10.0f, 20.0f));
+    mainWin.cameraEntity->setPosition(QVector3D(20.0f, 10.0f, 0.0f));
     mainWin.cameraEntity->setUpVector(QVector3D(0, 1, 0));
     mainWin.cameraEntity->setViewCenter(QVector3D(0, 0, 0));
 

--- a/qt-cao-editor/app/mainwindow.cpp
+++ b/qt-cao-editor/app/mainwindow.cpp
@@ -11,7 +11,7 @@
 
 #include "mainwindow.h"
 
-MainWindow::MainWindow()
+MainWindow::MainWindow() : useBlenderFrame(false)
 {
     createActions();
     createStatusBar();
@@ -204,7 +204,6 @@ void MainWindow::about()
 
 void MainWindow::createActions()
 {
-
     QMenu *caoMenu = menuBar()->addMenu(tr("&File"));
     QToolBar *caoToolBar = addToolBar(tr("File"));
 
@@ -215,6 +214,11 @@ void MainWindow::createActions()
     connect(openAct, &QAction::triggered, this, &MainWindow::open);
     caoMenu->addAction(openAct);
     caoToolBar->addAction(openAct);
+
+    QCheckBox *blenderFrameCB = new QCheckBox(tr("Use Blender frame"));
+    blenderFrameCB->setStatusTip(tr("Use Blender frame when importing ViSP .cao"));
+    connect(blenderFrameCB, &QCheckBox::stateChanged, this, &MainWindow::blenderFrameStateChanged);
+    caoToolBar->addWidget(blenderFrameCB);
 
 
     QAction *saveAct = new QAction(QIcon::fromTheme("document-save", QIcon(":/images/save.png")), tr("&Save"), this);
@@ -296,6 +300,10 @@ void MainWindow::writeSettings()
     settings.setValue("geometry", saveGeometry());
 }
 
+void MainWindow::blenderFrameStateChanged(int state)
+{
+    useBlenderFrame = (state == Qt::CheckState::Checked);
+}
 
 bool MainWindow::maybeSave()
 {
@@ -327,8 +335,7 @@ void MainWindow::loadCaoFile(const QString &fileName)
     }
 
     QTextStream in(&file);
-
-    modifier->parse3DFile(in);
+    modifier->parse3DFile(in, useBlenderFrame);
 
     file.close();
 

--- a/qt-cao-editor/app/mainwindow.h
+++ b/qt-cao-editor/app/mainwindow.h
@@ -22,22 +22,15 @@
 #include <Qt3DInput/QInputAspect>
 #include <Qt3DInput/QKeyboardHandler>
 
-#include <Qt3DRender/qcamera.h>
-#include <Qt3DRender/qcameralens.h>
-#include <Qt3DRender/qmesh.h>
-#include <Qt3DRender/qtechnique.h>
-#include <Qt3DRender/qmaterial.h>
-#include <Qt3DRender/qeffect.h>
-#include <Qt3DRender/qtexture.h>
-#include <Qt3DRender/qrenderpass.h>
-#include <Qt3DRender/qsceneloader.h>
-#include <Qt3DRender/qpointlight.h>
-#include <Qt3DRender/qenvironmentlight.h>
-#include <Qt3DRender/qrenderaspect.h>
+#include <Qt3DRender/QCamera>
+#include <Qt3DRender/QCameraLens>
+#include <Qt3DRender/QMesh>
+#include <Qt3DRender/QMaterial>
+#include <Qt3DRender/QPointLight>
 
-#include <Qt3DExtras/qforwardrenderer.h>
-#include <Qt3DExtras/qt3dwindow.h>
-#include <Qt3DExtras/qfirstpersoncameracontroller.h>
+#include <Qt3DExtras/QForwardRenderer>
+#include <Qt3DExtras/Qt3DWindow>
+#include <Qt3DExtras/QFirstPersonCameraController>
 
 #include "scenemodifier.h"
 #include "xmleditor.h"
@@ -84,6 +77,7 @@ private:
     void createStatusBar();
     void readSettings();
     void writeSettings();
+    void blenderFrameStateChanged(int state);
     bool maybeSave();
     bool saveFile(const QString &fileName);
     void setCurrentFile(const QString &fileName);
@@ -95,6 +89,7 @@ private:
     QDialog *dialog;
     QFormLayout *form;
     QList<QLineEdit *> qcamera_fields;
+    bool useBlenderFrame;
 };
 //! [0]
 

--- a/qt-cao-editor/app/scenemodifier.h
+++ b/qt-cao-editor/app/scenemodifier.h
@@ -9,9 +9,9 @@
 
 #include <QtCore/QObject>
 
-#include <Qt3DCore/qentity.h>
-#include <Qt3DCore/qtransform.h>
-#include <QtCore/qmath.h>
+#include <Qt3DCore/QEntity>
+#include <Qt3DCore/QTransform>
+#include <QtCore/QtMath>
 #include <QtCore/QFileInfo>
 #include <QtCore/QFile>
 
@@ -67,21 +67,21 @@ public:
 
 public slots:
     void mouseControls(Qt3DInput::QKeyEvent *event);
-    void parse3DFile(QTextStream &input);
+    void parse3DFile(QTextStream &input, const bool useBlenderFrame);
     void removeSceneElements();
 
 private slots:
     void handlePickerPress(Qt3DRender::QPickEvent *event);
-    void createCylinder(const QVector3D axis_1, const QVector3D axis_2,
-                        unsigned int index, float radius, QString load_param);
-    void createCircle(const QVector3D circum_1, const QVector3D circum_2, const QVector3D center,
-                      unsigned int index, float radius, QString load_param);
-    void createLines(const QVector3D v0, const QVector3D v1,
-                     const unsigned int index, const bool axis, QString lod_param);
+    void createCylinder(const QVector3D &axis_1, const QVector3D &axis_2,
+                        const unsigned int index, const float radius, const QString &load_param);
+    void createCircle(const QVector3D &circum_1, const QVector3D &circum_2, const QVector3D &center,
+                      const unsigned int index, const float radius, const QString &load_param);
+    void createLines(const QVector3D &v0, const QVector3D &v1,
+                     const unsigned int index, const bool axis, const QString &lod_param);
     void getLineLength();
 
     int primitiveType(const QString &type);
-    QString getLodParameters(QStringList data, const QString type,
+    QString getLodParameters(const QStringList &data, const QString &type,
                           const unsigned int idx1, const unsigned int idx2);
 
 private:


### PR DESCRIPTION
This should fix the rotation for cylinder and circle primitives.

Note: I had to add a transformation between Blender and Qt frame to be able to check if the rotation and the translation are correctly set.
